### PR TITLE
Downgrade jackson to ensure that servlet 3.x is running properly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     signing
     id("com.diffplug.gradle.spotless") version "3.27.2"
     id("com.github.johnrengelman.shadow") version "5.2.0"
-    id("io.freefair.lombok") version "5.0.0-rc6"
+    id("io.freefair.lombok") version "5.0.0"
 }
 
 group = "com.yunify"
@@ -114,12 +114,12 @@ val cucumberRuntime: Configuration by configurations.creating {
 // In this section you declare the dependencies for your production and test code
 dependencies {
     compileOnly("org.projectlombok:lombok:1.18.12")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.3")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.10.3")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.10")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.9.10.4")
 
     implementation("org.json:json:20190722")
     implementation("com.squareup.okhttp3:okhttp:3.12.10")
-    // it"s library"s consumer"s responsibility to choose a log implementation(and set log_level.)
+    // it's library's consumer's responsibility to choose a log implementation(and set log_level.)
     implementation("org.slf4j:slf4j-api:1.7.30")
     testImplementation("io.cucumber:cucumber-java:5.5.0")
     testImplementation("io.cucumber:cucumber-junit:5.5.0")

--- a/src/main/java/com/qingstor/sdk/upload/UploadManager.java
+++ b/src/main/java/com/qingstor/sdk/upload/UploadManager.java
@@ -28,6 +28,7 @@ import com.qingstor.sdk.request.RequestHandler;
 import com.qingstor.sdk.service.Bucket;
 import com.qingstor.sdk.utils.QSStringUtil;
 import java.io.File;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 /**
@@ -159,7 +160,7 @@ public class UploadManager {
             String json = new String(bytes);
             try {
                 this.uploadModel = om.readValue(json, UploadModel.class);
-            } catch (JsonProcessingException e) {
+            } catch (IOException e) {
                 throw new QSException(e.getMessage(), e);
             }
             // Check status of the task.

--- a/src/main/java/com/qingstor/sdk/utils/QSJSONUtil.java
+++ b/src/main/java/com/qingstor/sdk/utils/QSJSONUtil.java
@@ -15,10 +15,10 @@
  */
 package com.qingstor.sdk.utils;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.qingstor.sdk.annotation.ParamAnnotation;
 import com.qingstor.sdk.constants.QSConstant;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -396,7 +396,7 @@ public class QSJSONUtil {
 
     private static boolean initParameter(
             JSONObject o, Field[] fields, Class targetClass, Object targetObj)
-            throws NoSuchMethodException {
+            throws NoSuchMethodException, IOException {
         boolean hasParam = false;
         NextField:
         for (Field field : fields) {
@@ -418,15 +418,12 @@ public class QSJSONUtil {
                         Map<String, String> metadatas = new HashMap<>();
 
                         Map<String, Object> map = null;
-                        try {
-                            map = om.readValue(o.toString(), HashMap.class);
-                            for (Map.Entry<String, Object> entry : map.entrySet()) {
-                                String k = entry.getKey().toLowerCase();
-                                if (k.startsWith("x-qs-meta-")) {
-                                    metadatas.put(k, entry.getValue().toString());
-                                }
+                        map = om.readValue(o.toString(), HashMap.class);
+                        for (Map.Entry<String, Object> entry : map.entrySet()) {
+                            String k = entry.getKey().toLowerCase();
+                            if (k.startsWith("x-qs-meta-")) {
+                                metadatas.put(k, entry.getValue().toString());
                             }
-                        } catch (JsonProcessingException ignored) {
                         }
 
                         if (metadatas.size() > 0) {


### PR DESCRIPTION
One of SDK's dependency: jackson 2.10.x added module-info.class(to support >=java9 module), but it will cause runtime issue when running with Servlet 3.x.
Consider servlet 3.x is still exists in many production environment, I think it's better to downgrade this dependency to 2.9.x. 

check this link for details: https://stackoverflow.com/questions/45311295/error-scanning-entry-module-info-class-when-starting-jetty-server