### PR TITLE
EnvContext: Use enable_virtual_host_style to specify url style

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,12 +22,13 @@ protocol: 'https'
 # it's user's responsbility to provide a log framework implementation in their application.
 
 # Valid request url styles are "virtual_host_style" and "path_style"(default).
-virtual_host_enabled: false
+# Also replace previous config item: virtual_host_enabled.
+enable_virtual_host_style: false
 
 # cname_support is used when you want access object use your own domain.
 # You can aliasing a bucket by adding cname record to map your own domain to some bucket of qingstor.
 # then you can access your object of this bucket use your url with object path.
-# Note: if this value is set to true, virtual_host_enabled must be true too.
+# Note: if this value is set to true, enable_virtual_host_style must be true too.
 cname_support: false
 
 # optional

--- a/docs/example/config_zh.md
+++ b/docs/example/config_zh.md
@@ -21,7 +21,8 @@ connection_retries: 3
 log_level: 'warn'
 
 # Valid request url styles are "virtual_host_style" and "path_style"(default).
-virtual_host_enabled: false
+# Also replace previous config item: virtual_host_enabled.
+enable_virtual_host_style: false
 
 # optional
 http_config:

--- a/src/main/java/com/qingstor/sdk/config/EnvContext.java
+++ b/src/main/java/com/qingstor/sdk/config/EnvContext.java
@@ -15,7 +15,9 @@
  */
 package com.qingstor.sdk.config;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -53,6 +55,12 @@ public class EnvContext implements ParamValidate, Credentials {
     // default style, like this: https://bucket-name.zone-id.qingstor.com/object-name
     @Deprecated private String requestUrlStyle = "virtual_host_style";
 
+    /**
+     * virtual_host_enabled will also be supported in this minor version series. After that, it will
+     * be removed. Please use enable_virtual_host_style.
+     */
+    @JsonProperty("enable_virtual_host_style")
+    @JsonAlias("virtual_host_enabled")
     private boolean virtualHostEnabled = false;
 
     private HttpConfig httpConfig = DEFAULT_HTTP_CONFIG;

--- a/tests/config.yaml.example
+++ b/tests/config.yaml.example
@@ -8,7 +8,7 @@ port: 443
 protocol: https
 
 # Valid request url styles are "virtual_host_style" and "path_style"(default).
-virtual_host_enabled: false
+enable_virtual_host_style: false
 
 # Additional User-Agent
 additional_user_agent: "test/integration"


### PR DESCRIPTION
Support both `enable_virtual_host_style` and `virtual_host_enabled`(Temporarily, for compatibility) to specify url style.