### PR TITLE
Use endpoint instead of host/port etc

### DIFF
--- a/src/main/java/com/qingstor/sdk/service/Bucket.java
+++ b/src/main/java/com/qingstor/sdk/service/Bucket.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Most of operations in qingstore can be found in this class.<br>
+ * Most of operations in qingstor can be found in this class.<br>
  * Usage:
  *
  * <pre>
@@ -46,6 +46,9 @@ import java.util.Map;
  * </pre>
  *
  * Now you can use the object bucket to do the operations.
+ *
+ * <p>Note: If your endpoint is configured as a raw ip or localhost, the zone parameter in
+ * constructor can be ignored.
  */
 public class Bucket {
     private String zone;
@@ -54,7 +57,10 @@ public class Bucket {
     private ClientConfiguration clientCfg;
 
     public Bucket(EnvContext envContext, String zone, String bucketName) {
-        this(envContext, ClientConfiguration.from(envContext), zone, bucketName);
+        this.cred = envContext;
+        this.clientCfg = ClientConfiguration.from(envContext);
+        this.zone = zone;
+        this.bucketName = bucketName;
     }
 
     // Provided for {@code QingStor#getBucket()} only currently.

--- a/src/main/java/com/qingstor/sdk/utils/UrlUtils.java
+++ b/src/main/java/com/qingstor/sdk/utils/UrlUtils.java
@@ -71,6 +71,9 @@ public class UrlUtils {
     private static String buildCanonicalHost(
             HttpUrl endpoint, String zone, String bucket, ClientConfiguration config) {
         String host = endpoint.host();
+        if (config.isRawHost()) { // must be path style, no zone info is inserted.
+            return host;
+        }
         if (config.isCnameSupport() && escapeFromExcluded(host, config.cnameExcludeSet())) {
             return host;
         }

--- a/src/test/java/com/qingstor/sdk/config/EnvContextTest.java
+++ b/src/test/java/com/qingstor/sdk/config/EnvContextTest.java
@@ -16,7 +16,10 @@
 package com.qingstor.sdk.config;
 
 import com.qingstor.sdk.exception.QSException;
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -39,7 +42,6 @@ public class EnvContextTest {
                 "access_key_id: 'testkey'\n"
                         + "secret_access_key: 'test_asss'\n"
                         + "additional_user_agent: 'test/integration'\n"
-                        + "host: qingcloud.com\n"
                         + "port: 443\n"
                         + "protocol: https\n";
         File f = new File("/tmp/config.yaml");
@@ -56,8 +58,25 @@ public class EnvContextTest {
             EnvContext ctx = EnvContext.loadFromFile("/tmp/config.yaml");
             Assert.assertEquals(ctx.getAccessKeyId(), "testkey");
             Assert.assertEquals(ctx.getSecretAccessKey(), "test_asss");
-            Assert.assertEquals(ctx.getEndpoint().toString(), "https://qingcloud.com:443");
+            Assert.assertEquals(ctx.getEndpoint().toString(), "https://qingstor.com");
             Assert.assertEquals(ctx.getAdditionalUserAgent(), "test/integration");
+        }
+        String hostPart = "host: qingcloud.com\n";
+        config = config + hostPart;
+        bConf = false;
+        try {
+            OutputStream output = new FileOutputStream(f);
+            output.write(config.getBytes());
+            output.close();
+            bConf = true;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        if (bConf) {
+            EnvContext ctx = EnvContext.loadFromFile("/tmp/config.yaml");
+            Assert.assertEquals(ctx.getAccessKeyId(), "testkey");
+            Assert.assertEquals(ctx.getSecretAccessKey(), "test_asss");
+            Assert.assertEquals(ctx.getEndpoint().toString(), "https://qingcloud.com:443");
         }
     }
 }

--- a/template/sub_services.tmpl
+++ b/template/sub_services.tmpl
@@ -28,7 +28,7 @@ import com.qingstor.sdk.request.QSRequest;
 import com.qingstor.sdk.common.OperationContext;
 
 /**
- * Most of operations in qingstore can be found in this class.<br>
+ * Most of operations in qingstor can be found in this class.<br>
  * Usage:
  * <pre>
  * EnvContext env = new EnvContext("ACCESS_KEY_ID_EXAMPLE", "SECRET_ACCESS_KEY_EXAMPLE");
@@ -37,6 +37,8 @@ import com.qingstor.sdk.common.OperationContext;
  * Bucket bucket = new Bucket(env, zoneKey, bucketName);
  * </pre>
  * Now you can use the object bucket to do the operations.
+ *
+ * Note: If your endpoint is configured as a raw ip or localhost, the zone parameter in constructor can be ignored.
  */
 public class Bucket {
     private String zone;


### PR DESCRIPTION
Extra support:
If endpoint is configured as a raw ip address or localhost,
we should not insert zone info when build final host and MUST
use path style.