### PR TITLE
SDK version info is centrally managed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,8 @@ plugins {
 }
 
 group = 'com.yunify'
-version = '2.5.0'
+// Pass command-line option: -Psdk_version=x.x.x if you want build a different version.
+version = findProperty('sdk_version') ?: '2.5.1'
 
 repositories {
     mavenCentral()
@@ -20,6 +21,11 @@ java {
     withSourcesJar()
 }
 
+ext.sharedManifest = manifest {
+    attributes("Implementation-Title": project.name,
+            "Implementation-Version": project.version)
+}
+
 tasks {
     compileJava {
         configure options.encoding("UTF-8")
@@ -28,10 +34,8 @@ tasks {
         configure options.encoding("UTF-8")
     }
     jar {
-        manifest {
-            attributes("Implementation-Title": project.name,
-                            "Implementation-Version": project.version
-            )
+        manifest = project.manifest {
+            from sharedManifest
         }
     }
     javadoc {
@@ -45,14 +49,29 @@ tasks {
         }
     }
     task fatJar(type: Jar) {
+        manifest = project.manifest {
+            from sharedManifest
+        }
         archiveClassifier.set('all-deps')
-
         from sourceSets.main.output
-
         dependsOn configurations.runtimeClasspath
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         from {
             configurations.runtimeClasspath.findAll { it.name.endsWith("jar") }.collect { zipTree(it) }
         }
+    }
+    task versionProperties {
+        doLast {
+            mkdir "$buildDir/resources/main"
+            new File("$buildDir/resources/main/version.properties").withWriter { w ->
+                Properties p = new Properties()
+                p['version'] = project.version.toString()
+                p.store w, null
+            }
+        }
+    }
+    classes {
+        dependsOn versionProperties
     }
     build {
         dependsOn fatJar

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/qingstor/sdk/constants/QSConstant.java
+++ b/src/main/java/com/qingstor/sdk/constants/QSConstant.java
@@ -15,9 +15,12 @@
  */
 package com.qingstor.sdk.constants;
 
+import java.io.IOException;
+import java.util.Properties;
+
 public class QSConstant {
 
-    public static String SDK_VERSION = "2.5.0";
+    public static String SDK_VERSION = initVersion();
     public static String SDK_NAME = "qingstor-sdk-java";
 
     public static String QC_CODE_FIELD_NAME = "statue_code";
@@ -60,10 +63,6 @@ public class QSConstant {
 
     public static final String ENV_CONTEXT_KEY = "envContext";
 
-    public static final String SDK_TYPE_IAAS = "qingcloud_iaas";
-
-    public static final String SDK_TYPE_STOR = "qingcloud_stor";
-
     public static final String HEADER_PARAM_KEY_DATE = "Date";
 
     public static final String HEADER_PARAM_KEY_EXPIRES = "Expires";
@@ -77,13 +76,28 @@ public class QSConstant {
     public static final int REQUEST_ERROR_CODE = 10000;
     public static final int REQUEST_ERROR_CANCELLED = 20000;
 
-    public static int HTTPCLIENT_CONNECTION_TIME_OUT = 60; // Seconds
-    public static int HTTPCLIENT_READ_TIME_OUT = 100; // Seconds
-    public static int HTTPCLIENT_WRITE_TIME_OUT = 100; // Seconds
+    @Deprecated public static int HTTPCLIENT_CONNECTION_TIME_OUT = 60; // Seconds
+    @Deprecated public static int HTTPCLIENT_READ_TIME_OUT = 100; // Seconds
+    @Deprecated public static int HTTPCLIENT_WRITE_TIME_OUT = 100; // Seconds
 
     /** default url style, like this: https://bucket-name.zone-id.qingstor.com/object-name */
-    public static final String VIRTUAL_HOST_STYLE = "virtual_host_style";
+    @Deprecated public static final String VIRTUAL_HOST_STYLE = "virtual_host_style";
 
     /** https://zone-id.qingstor.com/bucket-name/object-name */
-    public static final String PATH_STYLE = "path_style";
+    @Deprecated public static final String PATH_STYLE = "path_style";
+
+    @Deprecated public static final String SDK_TYPE_IAAS = "qingcloud_iaas";
+
+    @Deprecated public static final String SDK_TYPE_STOR = "qingcloud_stor";
+
+    private static String initVersion() {
+        final String versionFile = "version.properties";
+        Properties info = new Properties();
+        try {
+            info.load(QSConstant.class.getClassLoader().getResourceAsStream(versionFile));
+            return info.getProperty("version");
+        } catch (IOException e) {
+            return "unspecified";
+        }
+    }
 }

--- a/src/test/java/com/qingstor/sdk/utils/QSStringUtilTest.java
+++ b/src/test/java/com/qingstor/sdk/utils/QSStringUtilTest.java
@@ -15,7 +15,6 @@
  */
 package com.qingstor.sdk.utils;
 
-import com.qingstor.sdk.constants.QSConstant;
 import java.util.HashMap;
 import java.util.Map;
 import org.json.JSONObject;
@@ -35,13 +34,6 @@ public class QSStringUtilTest {
         String[] values = {"2", "3"};
         String req = QSStringUtil.getParameterValueNotAllowedError("colume", "key", values);
         Assert.assertEquals(req, "colume value key is not allowed, should be one of 2,3 ");
-    }
-
-    @Test
-    public void testUserAgentString() {
-        String req = QSStringUtil.getUserAgent();
-        Assert.assertEquals(req.indexOf(QSConstant.SDK_VERSION) > 0, true);
-        Assert.assertEquals(req.indexOf(QSConstant.SDK_NAME) == 0, true);
     }
 
     @Test


### PR DESCRIPTION
Centrally manage the sdk version info in gradle, and the build will embed the generated properties file into the final jar.
When sdk is imported, the version info will be loaded and assigned to `SDK_VERSION`.