### PR TITLE
fix(lifecycle): Filter.Prefix is not a required field

### DIFF
--- a/src/main/java/com/qingstor/sdk/service/Types.java
+++ b/src/main/java/com/qingstor/sdk/service/Types.java
@@ -645,7 +645,7 @@ public class Types {
     /** FilterModel represents Filter. */
     public static class FilterModel extends RequestInputModel {
 
-        /** Prefix matching Required */
+        /** Prefix matching */
         private String prefix;
 
         public void setPrefix(String prefix) {
@@ -660,9 +660,7 @@ public class Types {
         /** validateParam validates the Filter. */
         @Override
         public String validateParam() {
-            if (QSStringUtil.isEmpty(this.getPrefix())) {
-                return QSStringUtil.getParameterRequired("Prefix", "Filter");
-            }
+
             return null;
         }
     }


### PR DESCRIPTION
if null is provided, server-side will treat it as empty string.