### PR TITLE
deps: Update okhttp to address CVE-2023-3635

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,7 @@ configurations {
 
 // In this section you declare the dependencies for your production and test code
 dependencies {
-    api 'com.squareup.okhttp3:okhttp:4.9.2'
+    api 'com.squareup.okhttp3:okhttp:4.12.0'
 
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.3'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'


### PR DESCRIPTION
okhttp v4.12.0 is the first version depends on okio v3.6.0, which address above issue.