### PR TITLE
fix(EnvContext): 更新过时的 Jackson PropertyNamingStrategy 用法

### DIFF
--- a/src/main/java/com/qingstor/sdk/config/EnvContext.java
+++ b/src/main/java/com/qingstor/sdk/config/EnvContext.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.qingstor.sdk.common.auth.Credentials;
@@ -47,7 +48,7 @@ public class EnvContext implements ParamValidate, Credentials {
 
     static {
         om = new ObjectMapper(new YAMLFactory());
-        om.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        om.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
     }
 
     private String accessKeyId;


### PR DESCRIPTION
将已弃用的 `PropertyNamingStrategy.SNAKE_CASE` 替换为 `PropertyNamingStrategies.SNAKE_CASE`