### PR TITLE
deps: Update jackson to address CVE-2026-54515

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to QingStor SDK for JAVA will be documented in this file.
 
+## [v2.6.9] - 2026-08-04
+
+### Changed
+
+- Migrate `PropertyNamingStrategy.SNAKE_CASE` to `PropertyNamingStrategies.SNAKE_CASE`.
+
+### Fixed
+
+- Update jackson to 2.21.5 to address CVE-2026-54515, CVE-2026-59889 and GHSA-mhm7-754m-9p8w.
+
 ## [v2.6.8] - 2026-07-14
 
 ### Changed

--- a/docs/install.md
+++ b/docs/install.md
@@ -22,7 +22,7 @@ Maven:
 <dependency>
   <groupId>com.yunify</groupId>
   <artifactId>qingstor.sdk.java</artifactId>
-  <version>2.6.8</version>
+  <version>2.6.9</version>
 </dependency>
 ```
 

--- a/docs/install_zh-CN.md
+++ b/docs/install_zh-CN.md
@@ -22,7 +22,7 @@ Maven:
 <dependency>
   <groupId>com.yunify</groupId>
   <artifactId>qingstor.sdk.java</artifactId>
-  <version>2.6.8</version>
+  <version>2.6.9</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,12 +53,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.18.8</version>
+            <version>2.21.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.18.8</version>
+            <version>2.21.5</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yunify</groupId>
     <artifactId>qingstor.sdk.java</artifactId>
-    <version>2.6.8</version>
+    <version>2.6.9</version>
     <name>Qingcloud Qingstor SDK for Java</name>
     <description>The official QingStor SDK for the Java programming language.</description>
     <url>https://www.qingcloud.com/products/objectstorage/</url>

--- a/src/main/java/com/qingstor/sdk/config/EnvContext.java
+++ b/src/main/java/com/qingstor/sdk/config/EnvContext.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.qingstor.sdk.common.auth.Credentials;
 import com.qingstor.sdk.exception.QSException;
@@ -47,7 +47,7 @@ public class EnvContext implements ParamValidate, Credentials {
 
     static {
         om = new ObjectMapper(new YAMLFactory());
-        om.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        om.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
     }
 
     private String accessKeyId;

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=2.6.8
+version=2.6.9


### PR DESCRIPTION
Jackson 2.18.8 is affected by CVE-2026-54515, CVE-2026-59889 and
GHSA-mhm7-754m-9p8w. Update jackson-databind and jackson-dataformat-yaml
to 2.21.5, which reports no known vulnerabilities.

Switch to PropertyNamingStrategies.SNAKE_CASE, which has been available
since 2.12, to replace the deprecated PropertyNamingStrategy constant.

Jackson 2.x keeps a Java 8 baseline, so java8 support is retained.